### PR TITLE
Added access to restart websocketclient

### DIFF
--- a/custom_components/mystiebel/websocket_client.py
+++ b/custom_components/mystiebel/websocket_client.py
@@ -175,10 +175,10 @@ class WebSocketClient:
 
     async def _authenticate(self) -> None:
         """Authenticate and update token."""
-        _LOGGER.debug("Authenticating for WebSocket connection")
-        await self.auth.authenticate()
+        _LOGGER.debug("Authenticating for WebSocket connection if token not valid")
+        await self.auth.ensure_valid_token()
         self.coordinator.set_token(self.auth.token)
-        _LOGGER.debug("Authentication successful")
+        _LOGGER.debug("(Re-)authentication successful")
 
     async def _create_connection(self) -> aiohttp.ClientWebSocketResponse:
         """Create WebSocket connection with proper headers."""

--- a/custom_components/mystiebel/websocket_client.py
+++ b/custom_components/mystiebel/websocket_client.py
@@ -74,7 +74,13 @@ class WebSocketClient:
         self._running = True
         self._task = None
         self._current_ws = None
-
+    
+    async def restart(self) -> None:
+        """Restart the WebSocket client cleanly."""
+        await self.stop()
+        self._running = True
+        self.start()
+    
     def start(self) -> None:
         """Start the WebSocket client as a background task."""
         self._task = self.hass.async_create_background_task(


### PR DESCRIPTION
The websocketclient can now be restarted. Furtheemore, authentificate is only performed when required 