### PR TITLE
Prepare v1.2.0 HACS release

### DIFF
--- a/custom_components/mystiebel/manifest.json
+++ b/custom_components/mystiebel/manifest.json
@@ -2,9 +2,10 @@
   "domain": "mystiebel",
   "name": "MyStiebel",
   "config_flow": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "integration_type": "device",
   "documentation": "https://www.github.com/sanderkwantes/mystiebel",
+  "issue_tracker": "https://github.com/sanderkwantes/mystiebel/issues",
   "codeowners": ["@sanderkwantes"],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
## Summary

- bump the integration version from `1.1.0` to `1.2.0`
- add the required issue tracker metadata for HACS

This prepares the changes from #14 for publication as a versioned HACS update.